### PR TITLE
Fix for LDEV-364

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/tag/util/QueryParamConverter.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/tag/util/QueryParamConverter.java
@@ -110,6 +110,8 @@ public class QueryParamConverter {
 		
 		// nulls (optional)
 		Object oNulls=sct.get(KeyConstants._nulls,null);
+		if(oNulls==null)oNulls=sct.get(KeyConstants._null,null);
+
 		if(oNulls!=null) {
 			item.setNulls(Caster.toBooleanValue(oNulls));
 		}

--- a/tests/testcases/jira/LDEV-364.cfc
+++ b/tests/testcases/jira/LDEV-364.cfc
@@ -10,6 +10,34 @@ component extends="org.lucee.cfml.test.LuceeTestCase"	{
 
 		describe( 'QueryExecute' , function(){
 
+			it( 'returns NULL when fed in through array parameter with nulls=true' , function() {
+
+				/*
+					I have no idea *why* this is this way, but in the source code I spotted this.
+					It turns out that there is an ability to cast to null but the parameter attribute
+					is "nulls" instead of "null", go figure!
+				*/
+
+				actual = QueryExecute(
+					options = {
+						dbtype: 'query'
+					},
+					params = [
+						{ type: 'integer' , value: 1 , nulls: true }
+					],
+					sql = "
+						SELECT 
+							COALESCE( ? , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					"
+				);
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+			});
+
 			it( 'returns NULL when fed in through array parameter with null=true' , function() {
 
 				actual = QueryExecute(

--- a/tests/testcases/jira/LDEV-364.cfc
+++ b/tests/testcases/jira/LDEV-364.cfc
@@ -1,0 +1,167 @@
+component extends="org.lucee.cfml.test.LuceeTestCase"	{
+
+	function beforeAll() {
+		variables.queryWithDataIn = Query(
+			id: [ 1 ]
+		);
+	}
+
+	function run( testResults , testBox ) {
+
+		describe( 'QueryExecute' , function(){
+
+			it( 'returns NULL when fed in through array parameter with null=true' , function() {
+
+				actual = QueryExecute(
+					options = {
+						dbtype: 'query'
+					},
+					params = [
+						{ type: 'integer' , value: 1 , null: true }
+					],
+					sql = "
+						SELECT 
+							COALESCE( ? , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					"
+				);
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+			});
+
+			it( 'returns NULL when fed in through array named parameter with null=true' , function() {
+
+				actual = QueryExecute(
+					options = {
+						dbtype: 'query'
+					},
+					params = [
+						{ name: 'input' , type: 'integer' , value: 1 , null: true }
+					],
+					sql = "
+						SELECT 
+							COALESCE( :input , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					"
+				);
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+			});
+
+			it( 'returns NULL when fed in through struct parameter with null=true' , function() {
+
+				actual = QueryExecute(
+					options = {
+						dbtype: 'query'
+					},
+					params = {
+						'input': { type: 'integer' , value: 1 , null: true }
+					},
+					sql = "
+						SELECT 
+							COALESCE( :input , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					"
+				);
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+
+			});
+
+		});
+
+		describe( 'new Query' , function(){
+
+			it( 'returns NULL when fed in through parameter with null=true' , function() {
+
+				q = new Query(
+					dbtype = 'query',
+					queryWithDataIn = variables.queryWithDataIn
+				);
+
+				q.addParam( type: 'integer' , value: 1 , null: true );
+
+				actual = q.execute( 
+					sql = "
+						SELECT 
+							COALESCE( ? , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					"
+				).getResult();
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+			});
+
+			it( 'returns NULL when fed in through named parameter with null=true' , function() {
+
+				q = new Query(
+					dbtype = 'query',
+					queryWithDataIn = variables.queryWithDataIn
+				);
+
+				q.addParam( name: 'input' , type: 'integer' , value: 1 , null: true );
+
+				actual = q.execute( 
+					sql = "
+						SELECT 
+							COALESCE( :input , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					"
+				).getResult();
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+			});
+
+		});
+
+		describe( 'cfquery in script' , function(){
+
+			it( 'returns NULL when fed in through parameter with null=true' , function() {
+
+				query
+					name = 'actual'
+					dbtype = 'query' {
+
+					WriteOutput( "
+
+						SELECT 
+							COALESCE( 
+					" );
+
+					queryparam
+						value = 1
+						sqltype = 'integer'
+						null = true;
+
+					WriteOutput( " , 'isnull' ) AS value,
+							COALESCE( NULL , 'isnull' ) AS control
+						FROM queryWithDataIn
+					" );
+				}
+
+				expect( actual.control[1] ).toBe( 'isnull' );
+				expect( actual.value[1] ).toBe( 'isnull' );
+
+			});
+
+		});
+
+	}
+	
+	
+} 


### PR DESCRIPTION
[LDEV-364](https://luceeserver.atlassian.net/browse/LDEV-364) indicates that "null=true" is not behaving as expected on QueryExecute specifically.  Digging into the source showed that "nulls=true" performed same function. 

Fix was to simply make it check attribute "null" if "nulls" was not defined, precedent for this logic was in the "cfsqltype" a few lines above.
