### PR TITLE
Update Document.java

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/tag/Document.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/tag/Document.java
@@ -74,7 +74,7 @@ public final class Document extends BodyTagImpl {
 	private int encryption=PDFDocument.ENC_NONE;
 
 	private String ownerpassword=null;
-	private String userpassword="empty";
+	private String userpassword="";
 	private int scale=-1;
 
 	// TODO impl. tag Document backgroundvisible,fontembed,scale


### PR DESCRIPTION
Set userpassword to "" by default.
Otherwise, when you encrypt a pdf document, it defaults the password to empty, which no one can figure out what it is, unless you search the code.
This is a compatibility bug, moving from ACF several documents started showing unknown passwords.
