### PR TITLE
Fixed error in web admin when access is read only

### DIFF
--- a/lucee-cfml/lucee-admin/admin/server.compiler.cfm
+++ b/lucee-cfml/lucee-admin/admin/server.compiler.cfm
@@ -142,7 +142,7 @@ Redirtect to entry --->
 							<input type="text" class="small" name="templateCharset" value="#setting.templateCharset#" />
 						<cfelse>
 							<input type="hidden" name="templateCharset" value="#setting.templateCharset#">
-							<b>#charset.templateCharset#</b>
+							<b>#setting.templateCharset#</b>
 						</cfif>
 						<div class="comment">#stText.charset.templateCharsetDescription#</div>
 						<cfsavecontent variable="codeSample">


### PR DESCRIPTION
Settings > Language/Compiler is not working in web admin, when access is read only.
