### PR TITLE
Fixed invalid syntax in mailing list link

### DIFF
--- a/lucee-cfml/lucee-admin/admin/overview.cfm
+++ b/lucee-cfml/lucee-admin/admin/overview.cfm
@@ -433,7 +433,7 @@ Error Output --->
 
 					<!--- Mailing list --->
 					<h3>
-						<a href="https://groups.google.com/forum/#!forum/lucee" target="_blank">#stText.Overview.Mailinglist#</a>
+						<a href="https://groups.google.com/forum/##!forum/lucee" target="_blank">#stText.Overview.Mailinglist#</a>
 					</h3>
 					<div class="comment">#stText.Overview.MailinglistDesc#</div>
 


### PR DESCRIPTION
Fixes invalid syntax introduced with ecbd9590974219278921cf19f2947759ba62f12d (LDEV-573).
