### PR TITLE
Fixed errors for read only web admin

### DIFF
--- a/lucee-cfml/lucee-admin/admin/debugging.settings.cfm
+++ b/lucee-cfml/lucee-admin/admin/debugging.settings.cfm
@@ -29,7 +29,7 @@
 	password="#session["password"&request.adminType]#"
 	returnVariable="access"
 	secType="debugging">
-<cfset hasAccess=access>
+<cfset hasAccess=(access EQ "yes")>
 
 
 <cftry>

--- a/lucee-cfml/lucee-admin/admin/resources.component.list.cfm
+++ b/lucee-cfml/lucee-admin/admin/resources.component.list.cfm
@@ -67,7 +67,7 @@
 						<cfif hasAccess>
 							<input type="checkbox" class="checkbox" name="componentDeepSearchDesc" value="yes" <cfif component.deepsearch>checked</cfif>>
 						<cfelse>
-							<b>#yesNoFormat(setting.deepsearch)#</b>
+							<b>#yesNoFormat(component.deepsearch)#</b>
 						</cfif>
 						<div class="comment">#stText.Components.componentDeepSearchDesc#</div>
 					</td>

--- a/lucee-cfml/lucee-admin/admin/server.compiler.cfm
+++ b/lucee-cfml/lucee-admin/admin/server.compiler.cfm
@@ -142,7 +142,7 @@ Redirtect to entry --->
 							<input type="text" class="small" name="templateCharset" value="#setting.templateCharset#" />
 						<cfelse>
 							<input type="hidden" name="templateCharset" value="#setting.templateCharset#">
-							<b>#charset.templateCharset#</b>
+							<b>#setting.templateCharset#</b>
 						</cfif>
 						<div class="comment">#stText.charset.templateCharsetDescription#</div>
 						<cfsavecontent variable="codeSample">

--- a/lucee-cfml/lucee-admin/admin/server.scope.cfm
+++ b/lucee-cfml/lucee-admin/admin/server.scope.cfm
@@ -328,8 +328,8 @@ function test() localMode="#scope.LocalMode#" {}
 							</ul>
 						<cfelse>
 							<input type="hidden" name="cgiReadonly" value="#scope.cgiReadonly#">
-							<b>#stText.Scopes["cgiReadOnly"& scope.LocalMode]#</b><br />
-							<div class="comment">#stText.Scopes["cgiReadOnly"& scope.LocalMode&"desc"]#</div>
+							<b>#stText.Scopes["cgiReadOnly"& scope.cgiReadOnly]#</b><br />
+							<div class="comment">#stText.Scopes["cgiReadOnly"& scope.cgiReadOnly&"desc"]#</div>
 						</cfif>
 						
 						<cfsavecontent variable="codeSample">


### PR DESCRIPTION
When locking down Security > Access settings for web admins to read only (General Access: Access Read: "password protected", Access Write: "closed", Web administrator: everything unchecked) some pages of the web admin throw exceptions.
