### PR TITLE
There was a typo in the sample provided for components.

### DIFF
--- a/lucee-cfml/lucee-admin/admin/resources.component.edit.cfm
+++ b/lucee-cfml/lucee-admin/admin/resources.component.edit.cfm
@@ -120,7 +120,7 @@
 
 
 <cfsavecontent variable="codeSample"><cfset count=0><cfset del="">
-this.componentpaths=["#mapping.virtual#"]=<cfif len(mapping.strPhysical) && !len(mapping.strArchive)>
+this.componentpaths["#mapping.virtual#"]=<cfif len(mapping.strPhysical) && !len(mapping.strArchive)>
 &nbsp;&nbsp;&nbsp;"#mapping.strPhysical#"<cfelse>{<cfif len(mapping.strPhysical)><cfset count++>
 &nbsp;&nbsp;&nbsp;physical:"#mapping.strPhysical#"<cfset del=","></cfif><cfif len(mapping.strArchive)><cfset count++>
 &nbsp;&nbsp;&nbsp;#del#archive:"#mapping.strArchive#"<cfset del=","></cfif><cfif count==2 && !mapping.PhysicalFirst>


### PR DESCRIPTION
In the administrator page "Archives & Resources", when someone chooses to create or edit a component resource, a sample of the `application.cfc` code is provided. The sample in this page has a typo. There is an equal (assignment) which is out of place in the context of adding a resource to `componentpaths`.
