### PR TITLE
fix for LDEV-742

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/db/ApplicationDataSource.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/db/ApplicationDataSource.java
@@ -29,26 +29,27 @@ import lucee.runtime.type.Struct;
 public class ApplicationDataSource extends DataSourceSupport {
 
 	private String connStr;
+	private boolean validate;
 
 	private ApplicationDataSource(String name, String className, String connStr, String username, String password,
-			boolean blob, boolean clob, int connectionLimit, int connectionTimeout, long metaCacheTimeout, TimeZone timezone, int allow, boolean storage, boolean readOnly) throws ClassException {
+			boolean blob, boolean clob, int connectionLimit, int connectionTimeout, long metaCacheTimeout, TimeZone timezone, int allow, boolean storage, boolean readOnly, boolean validate) throws ClassException {
 		this(name, toClass(className), connStr, username, password,
-				blob, clob, connectionLimit, connectionTimeout, metaCacheTimeout, timezone, allow, storage, readOnly);
+				blob, clob, connectionLimit, connectionTimeout, metaCacheTimeout, timezone, allow, storage, readOnly, validate);
 	}
 
 	private ApplicationDataSource(String name, Class clazz, String connStr, String username, String password,
-			boolean blob, boolean clob, int connectionLimit, int connectionTimeout, long metaCacheTimeout, TimeZone timezone, int allow, boolean storage, boolean readOnly) {
+			boolean blob, boolean clob, int connectionLimit, int connectionTimeout, long metaCacheTimeout, TimeZone timezone, int allow, boolean storage, boolean readOnly, boolean validate) {
 		super(name, clazz,username,ConfigWebFactory.decrypt(password),
 				blob,clob,connectionLimit, connectionTimeout, metaCacheTimeout, timezone, allow<0?ALLOW_ALL:allow, storage, readOnly);
-		
+		this.validate = validate;
 		this.connStr = connStr;
 	}
 	
 
 	public static DataSource getInstance(String name, String className, String connStr, String username, String password,
-			boolean blob, boolean clob, int connectionLimit, int connectionTimeout, long metaCacheTimeout, TimeZone timezone, int allow, boolean storage, boolean readOnly) throws ClassException {
+			boolean blob, boolean clob, int connectionLimit, int connectionTimeout, long metaCacheTimeout, TimeZone timezone, int allow, boolean storage, boolean readOnly, boolean validate) throws ClassException {
 		
-		return new ApplicationDataSource(name, className, connStr, username, password, blob, clob, connectionLimit, connectionTimeout, metaCacheTimeout, timezone, allow, storage, readOnly);
+		return new ApplicationDataSource(name, className, connStr, username, password, blob, clob, connectionLimit, connectionTimeout, metaCacheTimeout, timezone, allow, storage, readOnly, validate);
 	}
 
 	@Override
@@ -89,7 +90,7 @@ public class ApplicationDataSource extends DataSourceSupport {
 	@Override
 	public DataSource cloneReadOnly() {
 		return new ApplicationDataSource(getName(), getClazz(), connStr, getUsername(), getPassword(),
-				isBlob(), isClob(), getConnectionLimit(), getConnectionTimeout(), getMetaCacheTimeout(), getTimeZone(), allow, isStorage(), isReadOnly());
+				isBlob(), isClob(), getConnectionLimit(), getConnectionTimeout(), getMetaCacheTimeout(), getTimeZone(), allow, isStorage(), isReadOnly(), validate());
 	}
 
 	@Override
@@ -109,7 +110,7 @@ public class ApplicationDataSource extends DataSourceSupport {
 
 	@Override
 	public boolean validate() {
-		throw exp();
+		return validate;
 	}
 
 

--- a/lucee-java/lucee-core/src/lucee/runtime/listener/AppListenerUtil.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/listener/AppListenerUtil.java
@@ -82,6 +82,7 @@ public final class AppListenerUtil {
 	public static final Collection.Key ALLOW = KeyImpl.intern("allow");
 	public static final Collection.Key STORAGE = KeyImpl.intern("storage");
 	public static final Collection.Key READ_ONLY = KeyImpl.intern("readOnly");
+	public static final Collection.Key VALIDATE = KeyImpl.intern("validate");
 	public static final Collection.Key DATABASE = KeyConstants._database;
 	
 	public static PageSource getApplicationPageSource(PageContext pc,PageSource requestedPage, int mode,int type, RefBoolean isCFC) {
@@ -231,7 +232,8 @@ public final class AppListenerUtil {
 					Caster.toTimeZone(data.get(TIMEZONE,null),null), 
 					Caster.toIntValue(data.get(ALLOW,null),DataSource.ALLOW_ALL),
 					Caster.toBooleanValue(data.get(STORAGE,null),false),
-					Caster.toBooleanValue(data.get(READ_ONLY,null),false));
+					Caster.toBooleanValue(data.get(READ_ONLY,null),false),
+					Caster.toBooleanValue(data.get(VALIDATE,null),false));
 			
 			// then for {type:... , host:... , ...}
 			String type=Caster.toString(data.get(KeyConstants._type));


### PR DESCRIPTION
Allows the "validate" setting to be used on application level datasources.

this.datasource =  {
   ...
   validate: true
}

Which will check for valid connections on JDBC4 drivers.
