### PR TITLE
Admin extension bugfixes

### DIFF
--- a/lucee-cfml/lucee-admin/admin/extension.applications.install2.cfm
+++ b/lucee-cfml/lucee-admin/admin/extension.applications.install2.cfm
@@ -142,6 +142,22 @@
                 <cfset printError(struct(message:rst.common))>
             </cfif>
         </cfif>
+
+		<!--- For uploaded extensions: check if we need to update the image variable to point to a local file --->
+		<cfif done and structKeyExists(url, 'uploadExt')>
+			<cfset origImagePath = detail.data.image />
+			<cfif origImagePath neq "" and not refind('^https?:', origImagePath)>
+				<!--- does the file path to the image exist inside the extension zip file, and is it an image --->
+				<cfif fileExists(zip & origImagePath) and listFindNoCase("jpg,png,gif", listLast(origImagePath, '.'))
+						and not find('..', origImagePath)>
+					<cfset newImagePath = config.mixed.savePath & getFileFromPath(origImagePath) />
+					<cfif not fileExists(newImagePath)>
+						<cffile action="copy" source="#zip & origImagePath#" destination="#newImagePath#" />
+					</cfif>
+					<cfset detail.data.image = newImagePath />
+				</cfif>
+			</cfif>
+		</cfif>
         
         <cfif done>
             <cfadmin 

--- a/lucee-cfml/lucee-admin/admin/extension.applications.upload.cfm
+++ b/lucee-cfml/lucee-admin/admin/extension.applications.upload.cfm
@@ -22,11 +22,11 @@
 	<cflocation url="#request.self#?action=#url.action#&noextfile=1" addtoken="no" />
 </cfif>
 
-<!--- try to upload (.zip and .re) --->
+<!--- try to upload (.zip and .lex) --->
 <cftry>
 	<cffile action="upload" filefield="extfile" destination="#GetTempDirectory()#" nameconflict="makeunique" />
-	<cfif cffile.serverfileext neq "zip" and cffile.serverfileext neq "re">
-		<cfthrow message="Only zip and re files are allowed as extensions!" />
+	<cfif cffile.serverfileext neq "zip" and cffile.serverfileext neq "lex">
+		<cfthrow message="Only .zip and .lex files are allowed as extensions!" />
 	</cfif>
 	<cfcatch>
 		<!--- try to delete the uploaded file, if any--->
@@ -42,7 +42,7 @@
 
 <cfset zipfile = "#rereplace(cffile.serverdirectory, '[/\\]$', '')##server.separator.file##cffile.serverfile#" />
 	
-<!--- re files --->
+<!--- lex files --->
 <cfif cffile.serverfileext eq "lex">
 	<!--- move to deploy directory --->
 	<cfadmin 

--- a/lucee-cfml/lucee-admin/admin/extension.functions.cfm
+++ b/lucee-cfml/lucee-admin/admin/extension.functions.cfm
@@ -308,7 +308,7 @@
 		<cfargument name="width" required="yes" type="number" default="80">
 		<cfargument name="height" required="yes" type="number" default="40">
 		
-		<cfreturn "thumbnail.cfm?img=#urlEncodedFormat(imgUrl)#&width=#width#&height=#height#">
+		<cfreturn "thumbnail.cfm?img=#urlEncodedFormat(imgUrl)#&width=#width#&height=#height#&adminType=#request.adminType#">
 	</cffunction>    
 	
 	

--- a/lucee-cfml/lucee-admin/admin/extension.functions.cfm
+++ b/lucee-cfml/lucee-admin/admin/extension.functions.cfm
@@ -113,10 +113,19 @@
 		
 		<cfset local.cfcNames="">
 				
-		<cfif !failed> <cfreturn datas></cfif>
+		<cfif !failed>
+			<cfreturn datas>
+		</cfif>
+
 		<cfset var names="">
 		<cfloop array="#arguments.providers#" item="local.cfcName">
-			
+			<!--- if we can use this provider's cached data because of lastModified setting, then skip retrieval --->
+			<cfif structKeyExists(datas, cfcName) and isStruct(datas[cfcName])
+					and structKeyExists(datas[cfcName], "getInfo")
+					and structKeyExists(datas[cfcName].getInfo, "lastModified")>
+				<cfcontinue />
+			</cfif>
+
 			<!--- when was the last try to recieve this data?, we try only every  --->
 	        <cfif !forcereload and
 				StructKeyExists(session,"cfcstries") and 
@@ -126,24 +135,25 @@
 				</cfif>
 			</cfif>
 			<cfset session.cfcstries[cfcName]=now()>
-			
-			
+
 			<cfset session.cfcs[cfcName]={}>
         	<cfset request.cfcs[cfcName]={}>
 			<cfset var name="t"&createUniqueId()>
-			<cfset listAppend(names,name)>
+			<cfset names = listAppend(names,name) />
 			<cfthread name="#name#" provider="#cfcName#" sess="#session.cfcs[cfcName]#" req="#request.cfcs[cfcName]#">
 				<cfsetting requesttimeout="50000">
 				<cftry>
 					<cfset var start=getTickCount()>
 					
 					<!--- list Applications --->
-					<cfhttp url="#attributes.provider#?returnFormat=serialize&method=listApplications" result="local.http">
+					<cfhttp url="#attributes.provider#?returnFormat=serialize&method=listApplications" result="local.http"
+							throwonerror="true">
 					<cfset attributes.req.listApplications=evaluate(http.fileContent)>
 					<cfset attributes.sess.listApplications=attributes.req.listApplications>
 					
 					<!--- get Info --->
-					<cfhttp url="#attributes.provider#?returnFormat=serialize&method=getInfo" result="local.http">
+					<cfhttp url="#attributes.provider#?returnFormat=serialize&method=getInfo" result="local.http"
+							throwonerror="true">
 					<cfset attributes.req.getInfo=evaluate(http.fileContent)>
 			        <cfset attributes.req.getInfo.lastModified=now()>
 			        <cfset attributes.sess.getInfo=attributes.req.getInfo>
@@ -159,7 +169,7 @@
 			</cfthread>
 		</cfloop>
 		<!--- <cfset systemOutput('<print-stack-trace>',true,true)>--->
-		<cfif arguments.timeout GT 0>
+		<cfif arguments.timeout GT 0 and names neq "">
 			<cfthread action="join" names="#names#" timeout="#arguments.timeout#"/>
 		</cfif>
 			

--- a/lucee-cfml/lucee-admin/admin/thumbnail.cfm
+++ b/lucee-cfml/lucee-admin/admin/thumbnail.cfm
@@ -1,17 +1,74 @@
-<cfapplication name='__LUCEE_STATIC_CONTENT' sessionmanagement='#false#' clientmanagement='#false#' 
+<cfset url.img=trim(url.img)>
+<cfparam name="url.adminType" default="web" />
+<cfset request.adminType = url.adminType />
+
+<!--- user has to be logged in --->
+<cfif not structKeyExists(session, "password#url.adminType#")>
+	<cfthrow message="You need to be logged in" />
+</cfif>
+
+<!--- url.img must match an image for an extension --->
+<cfif url.img neq "">
+	<cfset found = false />
+	<!--- Check if the url.img is set in one of the installed extensions --->
+	<cfadmin
+		action="getExtensions"
+		type="#url.adminType#"
+		password="#session['password#url.adminType#']#"
+		returnVariable="extensions" />
+	<cfloop query="extensions">
+		<cfif extensions.image eq url.img>
+			<cfset found = true />
+			<cfbreak />
+		</cfif>
+	</cfloop>
+
+	<!--- Now check if it is among the uninstalled extensions, if the url.img is a valid URL --->
+	<cfif not found and isValid('url', url.img)>
+		<cfinclude template="extension.functions.cfm" />
+		<cfset data = loadAllProvidersData(timeout=1000) />
+
+		<!--- loop through all extension providers, check their extension images --->
+		<cfloop collection="#data#" item="cfcData" index="key">
+			<cfif not isStruct(cfcData) or not structKeyExists(cfcData, "listApplications")>
+				<cfcontinue />
+			</cfif>
+			<cfloop query="cfcData.listApplications">
+				<cfif cfcData.listApplications.image eq url.img>
+					<cfset found = true />
+					<cfbreak />
+				</cfif>
+			</cfloop>
+			<cfif found>
+				<cfbreak />
+			</cfif>
+		</cfloop>
+	</cfif>
+	<!--- Image not found? Bad bad bad --->
+	<cfif not found>
+		<cfthrow message="The image you wanted to view, cannot be found in any of the extensions" detail="img=#url.img#" />
+	</cfif>
+</cfif>
+
+<!--- go to a non-default application scope, for storing the image cache data --->
+<cfapplication name='__LUCEE_STATIC_CONTENT' sessionmanagement='false' clientmanagement='false'
 				applicationtimeout='#createtimespan( 1, 0, 0, 0 )#'>
 	
 	<cfsetting showdebugoutput="no">
 	<cfparam name="url.width" default="80">
 	<cfparam name="url.height" default="40">
-	<cfset url.img=trim(url.img)>
 	<cfset id=hash(url.img&"-"&url.width&"-"&url.height)>
-	<cfset mimetypes={png:'png',gif:'gif',jpg:'jpeg'}>
+	<cfset mimetypes={png:'image/png',gif:'image/gif',jpg:'image/jpeg'}>
 	
 	<cfif len(url.img) ==0>
 		<cfset ext="gif"><!--- using tp.gif in that case --->
 	<cfelse>
 	    <cfset ext=listLast(url.img,'.')>
+	</cfif>
+
+	<!--- check for valid file extension --->
+	<cfif not structKeyExists(mimetypes, ext)>
+		<cfthrow message="Invalid request for file [#url.img#]" />
 	</cfif>
 		
 	<cfheader name='Expires' value='#getHttpTimeString( now() + 100 )#'>
@@ -19,46 +76,61 @@
 	<cfset etag=hash(id)>	
 	<cfheader name='ETag' value='#etag#'>
 
-	<!--- etag matches, return 304 !--->
-	<cfif len( CGI.HTTP_IF_NONE_MATCH ) && ( CGI.HTTP_IF_NONE_MATCH == '#etag#' )>
-		<cfheader statuscode='304' statustext='Not Modified'>
-		<cfcontent reset='#true#' type='#mimetypes[ext]#'><cfabort>
-	</cfif>
-
 	<!--- copy and shrink to local dir --->
 	<cfset tmpfile=expandPath("{temp-directory}/admin-ext-thumbnails/"&id&"."&ext)>	
 	<cfif fileExists(tmpfile)>
+		<!--- etag matches, return 304 !--->
+		<cfif len( CGI.HTTP_IF_NONE_MATCH ) && ( CGI.HTTP_IF_NONE_MATCH == '#etag#' )>
+			<cfheader statuscode='304' statustext='Not Modified'>
+			<cfcontent reset='#true#' type='#mimetypes[ext]#'><cfabort>
+		</cfif>
+		<!--- No eTag given? Read the tmp image for processing --->
 		<cffile action="readbinary" file="#tmpfile#" variable="data">
 	<cfelseif len(url.img) ==0>
 		<cfset data=toBinary("R0lGODlhMQApAIAAAGZmZgAAACH5BAEAAAAALAAAAAAxACkAAAIshI+py+0Po5y02ouz3rz7D4biSJbmiabqyrbuC8fyTNf2jef6zvf+DwwKeQUAOw==")>
-		
 	<cfelse>
-		<cfif fileExists(url.img)>
-			<cffile action="readbinary" file="#url.img#" variable="data">
+		<!--- requested file does not exist? --->
+		<cfif not fileExists(url.img)>
+			<cfthrow message="Image requested does not exist (img=#url.img#)" />
+		<!--- check if the file is within the Lucee directories, if it is a local file --->
+		<cfelseif not isValid('url', url.img)>
+			<cfset checkPath = replace(url.img, '\', '/', 'all') />
+			<cfif findNoCase(replace(expandPath('{lucee-web}'), '\', '/', 'all'), checkPath) neq 1
+			  and findNoCase(replace(expandPath('{lucee-server}'), '\', '/', 'all'), checkPath) neq 1>
+				<cfthrow message="Image requested is not within the web/server context directory (img=#url.img#)" />
+			</cfif>
+		</cfif>
+
+		<cffile action="readbinary" file="#url.img#" variable="data">
+
 		<!--- base64 encoded binary --->
+		<!--- PK: not used in the admin anywhere, so removed.
+			  (code would have crashed anyway at the file extension check above)
 		<cfelse>
 			<cftry>
 				<cfset data=toBinary(url.img)>
 				<cfcatch><cfset systemOutput(e,true,true)></cfcatch>
 			</cftry>
 		</cfif>
-		<cfimage action="read" source="#data#" name="img">
-
-		<!--- shrink images if needed --->
-		<cfif img.height GT url.height or img.width GT url.width>
-			<cfif img.height GT url.height >
-				<cfimage action="resize" source="#img#" height="#url.height#" name="img">
-			</cfif>
-			<cfif img.width GT url.width>
-				<cfimage action="resize" source="#img#" width="#url.width#" name="img">
-			</cfif>
-			<cfset data=toBinary(img)>
-		</cfif>
-		
-		<cftry>
-			<cffile action="write" file="#tmpfile#" output="#data#" createPath="true">
-			<cfcatch><cfrethrow></cfcatch><!--- if it fails because there is no permission --->
-		</cftry>
+		--->
 	</cfif>
-	
+
+	<cfimage action="read" source="#data#" name="img">
+
+	<!--- shrink images if needed --->
+	<cfif img.height GT url.height or img.width GT url.width>
+		<cfif img.height GT url.height >
+			<cfimage action="resize" source="#img#" height="#url.height#" name="img">
+		</cfif>
+		<cfif img.width GT url.width>
+			<cfimage action="resize" source="#img#" width="#url.width#" name="img">
+		</cfif>
+		<cfset data=toBinary(img)>
+	</cfif>
+
+	<cftry>
+		<cffile action="write" file="#tmpfile#" output="#data#" createPath="true">
+		<cfcatch><cfrethrow></cfcatch><!--- if it fails because there is no permission --->
+	</cftry>
+
 	<cfcontent reset="yes" type="#mimetypes[ext]#" variable="#data#">


### PR DESCRIPTION
Multiple admin extension bugfixes:
- .lex extensions could not be uploaded in the admin
- If you uploaded an extension with a logo inside, the logo wasn't displayed in the admin afterwards
- Admin function loadProvidersData() incorrectly reloaded all providers every 60 seconds if only one of them could not be loaded.
- Added security checks for thumbnail.cfm
