### PR TITLE
LDEV-688 Fixes StackOverflowError logged in LDEV-488

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/db/DatasourceManagerImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/db/DatasourceManagerImpl.java
@@ -134,8 +134,8 @@ public final class DatasourceManagerImpl implements DataSourceManager {
                 	throw new DatabaseException(
     						"can't use different connections to the same datasource inside a single transaction",null,null,newDC);
     			}
-                else if(newDC.getConnection().getAutoCommit()) {
-                	newDC.getConnection().setAutoCommit(false);
+                else if(newDC.isAutoCommit()) {
+                	newDC.setAutoCommit(false);
                 }
             } catch (SQLException e) {
                ExceptionHandler.printStackTrace(e);

--- a/lucee-java/lucee-core/src/lucee/runtime/orm/ORMDatasourceConnection.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/orm/ORMDatasourceConnection.java
@@ -56,6 +56,14 @@ public class ORMDatasourceConnection implements DatasourceConnection {
 		connection.begin();
 		return connection;
 	}
+	
+	public boolean isAutoCommit() throws SQLException {
+		return connection.getAutoCommit();
+	}
+	
+	public void setAutoCommit(boolean setting) throws SQLException {
+		connection.setAutoCommit(setting);
+	}
 
 	@Override
 	public DataSource getDatasource() {


### PR DESCRIPTION
Prevents a call to getConnection()'s transaction.begin() call which causes a recursive loop that ends in tragedy.
