### PR TITLE
LDEV-1391 make connection NULL after closing it to avoid endless loop

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/db/DatasourceConnectionPool.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/db/DatasourceConnectionPool.java
@@ -64,6 +64,7 @@ public class DatasourceConnectionPool {
 			// we have a bad connection
 			if(rtn!=null) {
 				IOUtil.closeEL(rtn.getConnection());
+				rtn=null;
 			}
 			synchronized (stack) {
 				while(max!=-1 && max<=_size(datasource)) {


### PR DESCRIPTION
Issue being that, once the connection stack is empty, the condition that checks for the connection being not null or invalid will always be true because the connection is not null and not valid (it is closed)