### PR TITLE
LDEV-2230 error stacktrace generation performance

### DIFF
--- a/lucee-java/lucee-core/src/lucee/runtime/exp/PageExceptionImpl.java
+++ b/lucee-java/lucee-core/src/lucee/runtime/exp/PageExceptionImpl.java
@@ -595,23 +595,7 @@ public String getStackTraceAsString() {
     	if(trace.getFileName()==null || trace.getFileName().endsWith(".java"))
     		return trace.toString();
     	if(config!=null) {
-	    	Resource res = config.getResource(
-	    			trace.getFileName());
-	    	if(res.exists()) path=trace.getFileName();
-	    	
-	    	// get path from source
-	    	if(path==null){
-				SourceInfo si=MappingUtil.getMatch(pc,config,trace);
-				if(si!=null) {
-					String abs=si.absolutePath(pc);
-					if(!StringUtil.isEmpty(abs)) {
-						Resource r = config.getResource(abs);
-						if(r.exists()) path=abs;
-					}
-					if(path==null && si.relativePath!=null) path=si.relativePath;
-				}
-				if(path==null) path=trace.getFileName();
-	    	}
+		path = abs((PageContextImpl)pc, trace.getFileName());
     	}
 		return trace.getClassName() + "." + trace.getMethodName() +
         (trace.isNativeMethod() ? "(Native Method)" :
@@ -620,7 +604,22 @@ public String getStackTraceAsString() {
           (path != null ?  "("+path+")" : "(Unknown Source)")));
 
 	}
-    
+
+	private static String abs(PageContextImpl pc, String template) {
+		ConfigWeb config = pc.getConfig();
+
+		Resource res = config.getResource(template);
+		if(res.exists()) return template;
+
+		PageSource ps = pc==null?null:pc.getPageSource(template);
+		res = ps==null?null:ps.getPhyscalFile();
+		if(res==null || !res.exists()) {
+			res=config.getResource(ps.getDisplayPath());
+			if(res!=null && res.exists()) return res.getAbsolutePath();
+		}
+		else return res.getAbsolutePath();
+		return template;
+	}
     
 	private static StackTraceElement[] getStackTraceElements(Throwable t) {
     	StackTraceElement[] st=getStackTraceElements(t,true);


### PR DESCRIPTION
Use method used elsewhere to expand file path of relative template path.

Do this, rather than searching all mappings for classes which leads to performance and locking issues.